### PR TITLE
Move graphQL queries from index to containers

### DIFF
--- a/src/containers/Competitions.tsx
+++ b/src/containers/Competitions.tsx
@@ -1,28 +1,77 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { RootState, Group } from '../types';
+import { useStaticQuery, graphql } from 'gatsby';
+
+import { RootState, Group, GroupNode } from '../types';
 import { updateFilters } from '../state/actions';
 import FilterType from '../enum/FilterType';
+import { parseGroup } from '../utils/torneopalParser';
+
 import CompetitionsTables from '../components/CompetitionsTables/CompetitionsTables';
 
-type Props = {
-  items: Group[];
-};
-
-const Competitions = ({ items = [] }: Props) => {
+const Competitions = () => {
   const filters = useSelector((state: RootState) => state.tableFilters);
   const dispatch = useDispatch();
+
+  const data: GroupsQueryData = useStaticQuery(groupsQuery);
+  const groups: Group[] = (data?.groups?.edges ?? []).map((edge) =>
+    parseGroup(edge.node)
+  );
 
   const onUpdateFilters = (property: string, values: string[]) =>
     dispatch(updateFilters(FilterType.TABLES, { [property]: values }));
 
   return (
     <CompetitionsTables
-      groups={items}
+      groups={groups}
       filters={filters}
       updateFilters={onUpdateFilters}
     />
   );
 };
+
+type GroupsQueryData = {
+  groups: {
+    edges: {
+      node: GroupNode;
+    }[];
+  };
+};
+
+const groupsQuery = graphql`
+  query GroupsQuery {
+    groups: allTorneopalGroup {
+      edges {
+        node {
+          id
+          title
+          competition_id
+          category_name
+          group_name
+          live_standings {
+            team_name
+            team_id
+            current_standing
+            points
+            matches_played
+            matches_tied
+            matches_lost
+            matches_won
+            goals_for
+            goals_against
+          }
+          # Documenting the player stats fields here for future use.
+          # player_statistics {
+          #   player_name
+          #   team_id
+          #   team_name
+          #   standing
+          #   goals
+          # }
+        }
+      }
+    }
+  }
+`;
 
 export default Competitions;

--- a/src/containers/Fixtures.tsx
+++ b/src/containers/Fixtures.tsx
@@ -1,28 +1,62 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Fixture, RootState } from '../types';
+import { useStaticQuery, graphql } from 'gatsby';
+
+import { RootState, MatchNode, Fixture } from '../types';
 import { updateFilters } from '../state/actions';
+import { parseFixture } from '../utils/torneopalParser';
 import FilterType from '../enum/FilterType';
+
 import FixturesList from '../components/FixturesList/FixturesList';
 
-type Props = {
-  items: Fixture[];
-};
-
-const Fixtures = ({ items = [] }: Props) => {
+const Fixtures = () => {
   const filters = useSelector((state: RootState) => state.fixtureFilters);
   const dispatch = useDispatch();
+
+  const data: FixturesQueryData = useStaticQuery(fixturesQuery);
+  const fixtures: Fixture[] = (data?.fixtures?.edges ?? []).map((edge) =>
+    parseFixture(edge.node)
+  );
 
   const onUpdateFilters = (property: string, values: string[]) =>
     dispatch(updateFilters(FilterType.FIXTURES, { [property]: values }));
 
   return (
     <FixturesList
-      fixtures={items}
+      fixtures={fixtures}
       filters={filters}
       updateFilters={onUpdateFilters}
     />
   );
 };
+
+type FixturesQueryData = {
+  fixtures: {
+    edges: {
+      node: MatchNode;
+    }[];
+  };
+};
+
+const fixturesQuery = graphql`
+  query FixturesQuery {
+    fixtures: allTorneopalMatch {
+      edges {
+        node {
+          id
+          date
+          time
+          category_name
+          venue_name
+          team_A_name
+          team_B_name
+          fs_A
+          fs_B
+          status
+        }
+      }
+    }
+  }
+`;
 
 export default Fixtures;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,109 +1,24 @@
 import React from 'react';
-import { graphql } from 'gatsby';
 
-import { parseFixture, parseGroup } from '../utils/torneopalParser';
-
+import Fixtures from '../containers/Fixtures';
+import Competitions from '../containers/Competitions';
 import Layout from '../components/layout/Layout';
 import Grid from '../components/layout/Grid';
 import BorderedContainer from '../components/layout/BorderedContainer';
-import Fixtures from '../containers/Fixtures';
-import Competitions from '../containers/Competitions';
-import { GroupNode, MatchNode } from '../types';
 
-type Props = {
-  data: {
-    groups: {
-      edges: {
-        node: GroupNode;
-      }[];
-    };
-    fixtures: {
-      edges: {
-        node: MatchNode;
-      }[];
-    };
-  };
-};
-
-const IndexPage = ({ data }: Props) => {
-  const groups = data?.groups?.edges ?? [];
-  const fixtures = data?.fixtures?.edges ?? [];
-
-  return (
-    <Layout>
-      <Grid>
-        <BorderedContainer>
-          <h3 id="otteluohjelma">Otteluohjelma</h3>
-          <Fixtures
-            items={fixtures.map((edge: { node: MatchNode }) =>
-              parseFixture(edge.node)
-            )}
-          />
-        </BorderedContainer>
-        <BorderedContainer>
-          <h3 id="sarjataulukot">Sarjataulukot</h3>
-          <Competitions
-            items={groups.map((edge: { node: GroupNode }) =>
-              parseGroup(edge.node)
-            )}
-          />
-        </BorderedContainer>
-      </Grid>
-    </Layout>
-  );
-};
+const IndexPage = () => (
+  <Layout>
+    <Grid>
+      <BorderedContainer>
+        <h3 id="otteluohjelma">Otteluohjelma</h3>
+        <Fixtures />
+      </BorderedContainer>
+      <BorderedContainer>
+        <h3 id="sarjataulukot">Sarjataulukot</h3>
+        <Competitions />
+      </BorderedContainer>
+    </Grid>
+  </Layout>
+);
 
 export default IndexPage;
-
-// eslint-disable-next-line no-undef
-export const query = graphql`
-  {
-    fixtures: allTorneopalMatch {
-      edges {
-        node {
-          id
-          date
-          time
-          category_name
-          venue_name
-          team_A_name
-          team_B_name
-          fs_A
-          fs_B
-          status
-        }
-      }
-    }
-    groups: allTorneopalGroup {
-      edges {
-        node {
-          id
-          title
-          competition_id
-          category_name
-          group_name
-          live_standings {
-            team_name
-            team_id
-            current_standing
-            points
-            matches_played
-            matches_tied
-            matches_lost
-            matches_won
-            goals_for
-            goals_against
-          }
-          # Documenting the player stats fields here for future use.
-          # player_statistics {
-          #   player_name
-          #   team_id
-          #   team_name
-          #   standing
-          #   goals
-          # }
-        }
-      }
-    }
-  }
-`;

--- a/src/pages/kullervo-sata.tsx
+++ b/src/pages/kullervo-sata.tsx
@@ -146,7 +146,6 @@ const Page = ({ data }: Props) => {
 
 export default Page;
 
-// eslint-disable-next-line no-undef
 export const query = graphql`
   {
     file(relativePath: { eq: "img/100-v-braku.jpg" }) {


### PR DESCRIPTION
Use Gatsby's static queries (with the `useStaticQuery` hook) in containers instead of index-level bulk query.