### PR TITLE
Lift filter logic to containers

### DIFF
--- a/src/components/CompetitionsTables/CompetitionsTables.tsx
+++ b/src/components/CompetitionsTables/CompetitionsTables.tsx
@@ -1,60 +1,23 @@
 import React from 'react';
-import orderBy from 'lodash/orderBy';
-import memoize from 'lodash/memoize';
-import uniq from 'lodash/uniq';
-import xor from 'lodash/xor';
 
-import { Group, TableFilters } from '../../types';
+import { Group } from '../../types';
 
-import Filter from '../Filter';
 import CompetitionsTableGroup from './CompetitionsTableGroup';
 
 type Props = {
   groups?: Group[];
-  filters: TableFilters;
-  updateFilters: (property: string, values: string[]) => void;
 };
 
-const parseCompetitions = memoize((groups: Group[]) =>
-  uniq(groups.map((group: Group) => group.competition)).sort()
-);
-
-const CompetitionsTables = ({ groups = [], filters, updateFilters }: Props) => {
-  const competitions = parseCompetitions(groups);
-
-  const filterGroups = (groups: Group[], filters: TableFilters) => {
-    const competitionFilters = (
-      filters.competition ?? []
-    ).filter((competition) => competitions.includes(competition)); // removing non-active competitions
-
-    return competitionFilters.length
-      ? groups.filter((group) => competitionFilters.includes(group.competition))
-      : groups;
-  };
-
-  const onChangeFilter = (property: 'competition', value: string) => {
-    const filterValues = xor(filters.competition?.slice(0) ?? [], [value]);
-    updateFilters(property, filterValues);
-  };
-
+const CompetitionsTables = ({ groups = [] }: Props) => {
   return (
     <>
-      <Filter
-        group="tables"
-        property="competition"
-        options={competitions}
-        selected={filters.competition}
-        onChange={(value) => onChangeFilter('competition', value)}
-      />
-      {orderBy(filterGroups(groups, filters), ['competition'], ['asc']).map(
-        (group) => (
-          <CompetitionsTableGroup
-            key={`${group.competition}: ${group.group}`}
-            title={`${group.title}`}
-            teams={group.teams}
-          />
-        )
-      )}
+      {groups.map((group) => (
+        <CompetitionsTableGroup
+          key={`${group.competition}: ${group.group}`}
+          title={`${group.title}`}
+          teams={group.teams}
+        />
+      ))}
     </>
   );
 };

--- a/src/components/FixturesList/FixturesList.tsx
+++ b/src/components/FixturesList/FixturesList.tsx
@@ -1,76 +1,20 @@
 import React, { Fragment } from 'react';
-import uniq from 'lodash/uniq';
-import memoize from 'lodash/memoize';
-import xor from 'lodash/xor';
 
-import { Fixture, FixtureFilters } from '../../types';
+import { Fixture } from '../../types';
 
-import Filter from '../Filter';
 import FixtureListEntry from './FixtureListEntry';
 import DateBadge from './DateBadge';
 
 type Props = {
   fixtures: Fixture[];
-  filters: FixtureFilters;
-  updateFilters: (property: string, values: string[]) => void;
 };
 
-const parseCompetitions = memoize((fixtures: Fixture[]) =>
-  uniq(fixtures.map((fixture) => fixture.competition)).sort()
-);
-
-const FixturesList = ({ fixtures = [], filters, updateFilters }: Props) => {
-  const competitions = parseCompetitions(fixtures);
-
-  const filterFixtures = (
-    fixtures: Fixture[],
-    filters: FixtureFilters
-  ): Fixture[] => {
-    // filter fixtures by completion status
-    const filtered: Fixture[] =
-      filters.upcoming && filters.upcoming.length
-        ? fixtures.filter((fixture) => !fixture.isCompleted)
-        : fixtures;
-
-    // filter fixtures by competition
-    const competitionFilters = (
-      filters.competition ?? []
-    ).filter((competition) => competitions.includes(competition)); // removing non-active competitions
-
-    return competitionFilters.length
-      ? filtered.filter((fixture) =>
-          competitionFilters.includes(fixture.competition)
-        )
-      : filtered;
-  };
-
-  const onChangeFilter = (
-    property: 'competition' | 'upcoming',
-    value: string
-  ) => {
-    const filterValues = xor(filters[property]?.slice(0) ?? [], [value]);
-    updateFilters(property, filterValues);
-  };
-
+const FixturesList = ({ fixtures = [] }: Props) => {
   let currentDate: Date;
 
   return (
     <>
-      <Filter
-        group="fixtures"
-        property="competition"
-        options={competitions}
-        selected={filters.competition}
-        onChange={(value) => onChangeFilter('competition', value)}
-      />
-      <Filter
-        group="fixtures"
-        property="upcoming"
-        options={['Näytä vain tulevat ottelut']}
-        selected={filters.upcoming}
-        onChange={(value) => onChangeFilter('upcoming', value)}
-      />
-      {filterFixtures(fixtures, filters).map((fixture) => {
+      {fixtures.map((fixture) => {
         const addDateBadge = currentDate !== fixture.date;
         currentDate = fixture.date;
 

--- a/src/components/FixturesList/__tests__/FixturesList.test.tsx
+++ b/src/components/FixturesList/__tests__/FixturesList.test.tsx
@@ -21,17 +21,7 @@ describe('FixturesList', () => {
         venue: 'Riihimäki Keskuskenttä TN',
       },
     ],
-    filters = {
-      competition: [],
-      upcoming: [],
-    },
-  }) => (
-    <FixturesList
-      fixtures={fixtures}
-      filters={filters}
-      updateFilters={jest.fn()}
-    />
-  );
+  }) => <FixturesList fixtures={fixtures} />;
 
   it('renders', async () => {
     const { asFragment, container } = render(component({}));

--- a/src/components/FixturesList/__tests__/__snapshots__/FixturesList.test.tsx.snap
+++ b/src/components/FixturesList/__tests__/__snapshots__/FixturesList.test.tsx.snap
@@ -3,40 +3,6 @@
 exports[`FixturesList renders 1`] = `
 <DocumentFragment>
   <div
-    class="root"
-  >
-    <div
-      class="option"
-    >
-      <label
-        for="filter_competition_fixtures_Regions Cup"
-      >
-        <input
-          id="filter_competition_fixtures_Regions Cup"
-          type="checkbox"
-        />
-        Regions Cup
-      </label>
-    </div>
-  </div>
-  <div
-    class="root"
-  >
-    <div
-      class="option"
-    >
-      <label
-        for="filter_upcoming_fixtures_Näytä vain tulevat ottelut"
-      >
-        <input
-          id="filter_upcoming_fixtures_Näytä vain tulevat ottelut"
-          type="checkbox"
-        />
-        Näytä vain tulevat ottelut
-      </label>
-    </div>
-  </div>
-  <div
     class="root completed"
   >
     <div
@@ -91,40 +57,6 @@ exports[`FixturesList renders 1`] = `
 
 exports[`FixturesList renders with undefined fixtures 1`] = `
 <DocumentFragment>
-  <div
-    class="root"
-  >
-    <div
-      class="option"
-    >
-      <label
-        for="filter_competition_fixtures_Regions Cup"
-      >
-        <input
-          id="filter_competition_fixtures_Regions Cup"
-          type="checkbox"
-        />
-        Regions Cup
-      </label>
-    </div>
-  </div>
-  <div
-    class="root"
-  >
-    <div
-      class="option"
-    >
-      <label
-        for="filter_upcoming_fixtures_Näytä vain tulevat ottelut"
-      >
-        <input
-          id="filter_upcoming_fixtures_Näytä vain tulevat ottelut"
-          type="checkbox"
-        />
-        Näytä vain tulevat ottelut
-      </label>
-    </div>
-  </div>
   <div
     class="root completed"
   >

--- a/src/containers/Fixtures.tsx
+++ b/src/containers/Fixtures.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useStaticQuery, graphql } from 'gatsby';
+import xor from 'lodash/xor';
 
-import { RootState, MatchNode, Fixture } from '../types';
+import { RootState, MatchNode, Fixture, FixtureFilters } from '../types';
 import { updateFilters } from '../state/actions';
 import { parseFixture } from '../utils/torneopalParser';
+import parseCompetitions from '../utils/parseCompetitions';
 import FilterType from '../enum/FilterType';
 
+import Filter from '../components/Filter';
 import FixturesList from '../components/FixturesList/FixturesList';
 
 const Fixtures = () => {
@@ -17,17 +20,56 @@ const Fixtures = () => {
   const fixtures: Fixture[] = (data?.fixtures?.edges ?? []).map((edge) =>
     parseFixture(edge.node)
   );
+  const competitions = parseCompetitions(fixtures);
 
-  const onUpdateFilters = (property: string, values: string[]) =>
-    dispatch(updateFilters(FilterType.FIXTURES, { [property]: values }));
+  const onChangeFilter = (
+    property: 'competition' | 'upcoming',
+    value: string
+  ) => {
+    const filterValues = xor(filters[property]?.slice(0) ?? [], [value]);
+    dispatch(updateFilters(FilterType.FIXTURES, { [property]: filterValues }));
+  };
+
+  const filterFixtures = (
+    fixtures: Fixture[],
+    filters: FixtureFilters
+  ): Fixture[] => {
+    // filter fixtures by completion status
+    const filtered: Fixture[] =
+      filters.upcoming && filters.upcoming.length
+        ? fixtures.filter((fixture) => !fixture.isCompleted)
+        : fixtures;
+
+    // filter fixtures by competition
+    const competitionFilters = (
+      filters.competition ?? []
+    ).filter((competition) => competitions.includes(competition)); // removing non-active competitions
+
+    return competitionFilters.length
+      ? filtered.filter((fixture) =>
+          competitionFilters.includes(fixture.competition)
+        )
+      : filtered;
+  };
 
   return (
-    <FixturesList
-      // fixtures={fixtures.slice(0, 10)}
-      fixtures={fixtures}
-      filters={filters}
-      updateFilters={onUpdateFilters}
-    />
+    <>
+      <Filter
+        group="fixtures"
+        property="competition"
+        options={competitions}
+        selected={filters.competition}
+        onChange={(value) => onChangeFilter('competition', value)}
+      />
+      <Filter
+        group="fixtures"
+        property="upcoming"
+        options={['Näytä vain tulevat ottelut']}
+        selected={filters.upcoming}
+        onChange={(value) => onChangeFilter('upcoming', value)}
+      />
+      <FixturesList fixtures={filterFixtures(fixtures, filters)} />
+    </>
   );
 };
 

--- a/src/utils/parseCompetitions.ts
+++ b/src/utils/parseCompetitions.ts
@@ -1,0 +1,8 @@
+import uniq from 'lodash/uniq';
+import memoize from 'lodash/memoize';
+
+const parseCompetitions = memoize((items: { competition: string }[]) =>
+  uniq(items.map((item) => item.competition)).sort()
+);
+
+export default parseCompetitions;


### PR DESCRIPTION
Simplify components by lifting filtering to containers. Allows for easier re-use and clearer unit testing.