### PR TITLE
Remove margin from club logo

### DIFF
--- a/src/components/layout/Logo.module.css
+++ b/src/components/layout/Logo.module.css
@@ -1,5 +1,5 @@
 .root {
   width: 2.5em;
   height: 2.5em;
-  margin: 0.25em;
+  margin: 0;
 }


### PR DESCRIPTION
Club logo has excess margin. Remove to streamline Header layout.