### PR TITLE
Reduce initial dom size

### DIFF
--- a/src/containers/Competitions.tsx
+++ b/src/containers/Competitions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useStaticQuery, graphql } from 'gatsby';
 import xor from 'lodash/xor';

--- a/src/containers/Competitions.tsx
+++ b/src/containers/Competitions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useStaticQuery, graphql } from 'gatsby';
 import xor from 'lodash/xor';
@@ -9,11 +9,14 @@ import { updateFilters } from '../state/actions';
 import FilterType from '../enum/FilterType';
 import { parseGroup } from '../utils/torneopalParser';
 import parseCompetitions from '../utils/parseCompetitions';
+import useUserHasInteracted from '../hooks/useUserHasInteracted';
 
 import CompetitionsTables from '../components/CompetitionsTables/CompetitionsTables';
 import Filter from '../components/Filter';
 
 const Competitions = () => {
+  const userHasInteracted = useUserHasInteracted();
+
   const filters = useSelector((state: RootState) => state.tableFilters);
   const dispatch = useDispatch();
 
@@ -38,6 +41,12 @@ const Competitions = () => {
       : groups;
   };
 
+  const filteredGroups = orderBy(
+    filterGroups(groups, filters),
+    ['competition'],
+    ['asc']
+  ).slice(0, !userHasInteracted ? 2 : undefined);
+
   return (
     <>
       <Filter
@@ -47,13 +56,7 @@ const Competitions = () => {
         selected={filters.competition}
         onChange={(value) => onChangeFilter('competition', value)}
       />
-      <CompetitionsTables
-        groups={orderBy(
-          filterGroups(groups, filters),
-          ['competition'],
-          ['asc']
-        )}
-      />
+      <CompetitionsTables groups={filteredGroups} />
     </>
   );
 };

--- a/src/containers/Fixtures.tsx
+++ b/src/containers/Fixtures.tsx
@@ -5,14 +5,17 @@ import xor from 'lodash/xor';
 
 import { RootState, MatchNode, Fixture, FixtureFilters } from '../types';
 import { updateFilters } from '../state/actions';
+import FilterType from '../enum/FilterType';
 import { parseFixture } from '../utils/torneopalParser';
 import parseCompetitions from '../utils/parseCompetitions';
-import FilterType from '../enum/FilterType';
+import useUserHasInteracted from '../hooks/useUserHasInteracted';
 
 import Filter from '../components/Filter';
 import FixturesList from '../components/FixturesList/FixturesList';
 
 const Fixtures = () => {
+  const userHasInteracted = useUserHasInteracted();
+
   const filters = useSelector((state: RootState) => state.fixtureFilters);
   const dispatch = useDispatch();
 
@@ -68,7 +71,12 @@ const Fixtures = () => {
         selected={filters.upcoming}
         onChange={(value) => onChangeFilter('upcoming', value)}
       />
-      <FixturesList fixtures={filterFixtures(fixtures, filters)} />
+      <FixturesList
+        fixtures={filterFixtures(fixtures, filters).slice(
+          0,
+          !userHasInteracted ? 10 : undefined
+        )}
+      />
     </>
   );
 };

--- a/src/hooks/useUserHasInteracted.ts
+++ b/src/hooks/useUserHasInteracted.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+const useUserHasInteracted = () => {
+  const [userHasInteracted, setUserHasInteracted] = useState(false);
+
+  useEffect(() => {
+    const onInteract = () => {
+      clearListeners();
+      setUserHasInteracted(true);
+      console.log('onInteract');
+    };
+
+    document.body.addEventListener('mousemove', onInteract);
+    document.body.addEventListener('scroll', onInteract);
+    document.body.addEventListener('keydown', onInteract);
+    document.body.addEventListener('click', onInteract);
+    document.body.addEventListener('touchstart', onInteract);
+    document.body.addEventListener('wheel', onInteract);
+
+    const clearListeners = () => {
+      document.body.removeEventListener('mousemove', onInteract);
+      document.body.removeEventListener('scroll', onInteract);
+      document.body.removeEventListener('keydown', onInteract);
+      document.body.removeEventListener('click', onInteract);
+      document.body.removeEventListener('touchstart', onInteract);
+      document.body.removeEventListener('wheel', onInteract);
+    };
+
+    return () => clearListeners();
+  }, []);
+
+  return userHasInteracted;
+};
+
+export default useUserHasInteracted;


### PR DESCRIPTION
Render only a subset of fixtures and competition tables before user interaction. This should prevent excess dom size on initial load.